### PR TITLE
ci: bump action runtime node16 → node20 (node16 EOL)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: "E.g. secrets.GITHUB_TOKEN"
     required: true
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
node16 is EOL (GitHub Actions is dropping support). `dist/index.js` is an ncc bundle and node20 is backward-compatible; only the `using` field in action.yml changed. Part of the kungfu pre-check modernization goal (P0).