### PR TITLE
chore: promote node20 runtime dev -> alpha

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: "E.g. secrets.GITHUB_TOKEN"
     required: true
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kungfu-trader/action-check-format",
-  "version": "1.0.1-alpha.0",
+  "version": "1.0.1-alpha.1",
   "main": "dist/index.js",
   "repository": "https://github.com/kungfu-trader/action-check-format",
   "author": "Kungfu Trader",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kungfu-trader/action-check-format",
-  "version": "1.0.1-alpha.1",
+  "version": "1.0.2-alpha.0",
   "main": "dist/index.js",
   "repository": "https://github.com/kungfu-trader/action-check-format",
   "author": "Kungfu Trader",


### PR DESCRIPTION
Promote the node16->node20 runtime bump to the alpha channel for release. Part of kungfu pre-check modernization (P0-b).